### PR TITLE
Fix parse_file_with_callback fp need fclose

### DIFF
--- a/gen/util.c
+++ b/gen/util.c
@@ -284,6 +284,7 @@ parse_file_with_callback(const char *fname,
 
 	free(line);
 	free(field);
+	fclose(fp);
 }
 
 static int


### PR DESCRIPTION
on osx file open default is 256
```sh
> ulimit -n
256
```
run gen/bidirectional
```sh
./gen/bidirectional > gen/bidirectional.h
parse_file_with_callback: fopen 'data/UnicodeData.txt': Too many open files.
```
