### PR TITLE
Rework UTF-8 decode & encode functions

### DIFF
--- a/src/utf8.c
+++ b/src/utf8.c
@@ -7,52 +7,12 @@
 
 #define BETWEEN(c, l, u) ((c) >= (l) && (c) <= (u))
 
-/* lookup-table for the types of sequence first bytes */
-static const struct {
-	uint_least8_t lower;  /* lower bound of sequence first byte */
-	uint_least8_t upper;  /* upper bound of sequence first byte */
-	uint_least32_t mincp; /* smallest non-overlong encoded codepoint */
-	uint_least32_t maxcp; /* largest encodable codepoint */
-			      /*
-	                       * implicit: table-offset represents the number of following
-	                       * bytes of the form 10xxxxxx (6 bits capacity each)
-	                       */
-} lut[] = {
-	[0] = {
-		/* 0xxxxxxx */
-		.lower = 0x00, /* 00000000 */
-		.upper = 0x7F, /* 01111111 */
-		.mincp = (uint_least32_t)0,
-		.maxcp = ((uint_least32_t)1 << 7) - 1, /* 7 bits capacity */
-	},
-	[1] = {
-		/* 110xxxxx */
-		.lower = 0xC0, /* 11000000 */
-		.upper = 0xDF, /* 11011111 */
-		.mincp = (uint_least32_t)1 << 7,
-		.maxcp = ((uint_least32_t)1 << 11) - 1, /* 5+6=11 bits capacity */
-	},
-	[2] = {
-		/* 1110xxxx */
-		.lower = 0xE0, /* 11100000 */
-		.upper = 0xEF, /* 11101111 */
-		.mincp = (uint_least32_t)1 << 11,
-		.maxcp = ((uint_least32_t)1 << 16) - 1, /* 4+6+6=16 bits capacity */
-	},
-	[3] = {
-		/* 11110xxx */
-		.lower = 0xF0, /* 11110000 */
-		.upper = 0xF7, /* 11110111 */
-		.mincp = (uint_least32_t)1 << 16,
-		.maxcp = ((uint_least32_t)1 << 21) - 1, /* 3+6+6+6=21 bits capacity */
-	},
-};
-
 size_t
 grapheme_decode_utf8(const char *str, size_t len, uint_least32_t *cp)
 {
-	size_t off, i;
+	size_t i;
 	uint_least32_t tmp;
+	uint_least32_t mask;
 
 	if (cp == NULL) {
 		/*
@@ -68,20 +28,16 @@ grapheme_decode_utf8(const char *str, size_t len, uint_least32_t *cp)
 		return 0;
 	}
 
-	/* identify sequence type with the first byte */
-	for (off = 0; off < LEN(lut); off++) {
-		if (BETWEEN(((const unsigned char *)str)[0], lut[off].lower,
-		            lut[off].upper)) {
-			/*
-			 * first byte is within the bounds; fill
-			 * p with the the first bits contained in
-			 * the first byte (by subtracting the high bits)
-			 */
-			*cp = ((const unsigned char *)str)[0] - lut[off].lower;
-			break;
-		}
+	*cp = ((const unsigned char *)str)[0];
+	if (((const unsigned char *)str)[0] <= 0x7F) {
+		/*
+		 * ASCII range (0x00..0x7F); we assume ASCII characters
+		 * would appear the most often
+		 */
+		return 1;
 	}
-	if (off == LEN(lut)) {
+
+	if (!BETWEEN(((const unsigned char *)str)[0], 0xC2, 0xF4)) {
 		/*
 		 * first byte does not match a sequence type;
 		 * set cp as invalid and return 1 byte processed
@@ -92,128 +48,121 @@ grapheme_decode_utf8(const char *str, size_t len, uint_least32_t *cp)
 		*cp = GRAPHEME_INVALID_CODEPOINT;
 		return 1;
 	}
-	if (1 + off > len) {
-		/*
-		 * input is not long enough, set cp as invalid
-		 */
-		*cp = GRAPHEME_INVALID_CODEPOINT;
 
-		/*
-		 * count the following continuation bytes, but nothing
-		 * else in case we have a "rogue" case where e.g. such a
-		 * sequence starter occurs right before a NUL-byte.
-		 */
-		for (i = 0; 1 + i < len; i++) {
-			if (!BETWEEN(((const unsigned char *)str)[1 + i], 0x80,
-			             0xBF)) {
-				break;
-			}
-		}
+	mask = 1 << 6;
+	i = 1;
+	do {
+		mask <<= 5;
 
-		/*
-		 * if the continuation bytes do not continue until
-		 * the end, return the incomplete sequence length.
-		 * Otherwise return the number of bytes we actually
-		 * expected, which is larger than n.
-		 */
-		return ((1 + i) < len) ? (1 + i) : (1 + off);
-	}
-
-	/*
-	 * process 'off' following bytes, each of the form 10xxxxxx
-	 * (i.e. between 0x80 (10000000) and 0xBF (10111111))
-	 */
-	for (i = 1; i <= off; i++) {
-		if (!BETWEEN(((const unsigned char *)str)[i], 0x80, 0xBF)) {
+		*cp <<= 6;
+		if (i >= len) {
 			/*
-			 * byte does not match format; return
-			 * number of bytes processed excluding the
-			 * unexpected character as recommended since
-			 * Unicode 6 (chapter 3)
-			 *
-			 * this also includes the cases where bits
-			 * higher than the 8th are set on systems
-			 * with CHAR_BIT > 8
+			 * input is not long enough, continue the loop
+			 * to find the number of bytes expected for
+			 * this sequence.
+			 */
+			i++;
+			continue;
+		}
+		if (((const unsigned char *)str)[i] - 0x80U > 0x3FU) {
+			/* not a valid continuation byte */
+			*cp = GRAPHEME_INVALID_CODEPOINT;
+			return i;
+		}
+		*cp |= ((const unsigned char *)str)[i] - 0x80U;
+
+		/*
+		 * RFC-3629 requires us to treat the following cases as
+		 * invalid sequences
+		 */
+		if ((*cp >> 5) == 0x1C0) {
+			/*
+			 * first byte 0xE0, second byte 0x80..0x9F;
+			 * would form a 3-byte overlong sequence
 			 */
 			*cp = GRAPHEME_INVALID_CODEPOINT;
-			return 1 + (i - 1);
+			return i;
 		}
-		/*
-		 * shift codepoint by 6 bits and add the 6 stored bits
-		 * in s[i] to it using the bitmask 0x3F (00111111)
-		 */
-		*cp = (*cp << 6) | (((const unsigned char *)str)[i] & 0x3F);
-	}
+		if ((*cp >> 5) == 0x1DB) {
+			/*
+			 * first byte 0xED, second byte 0xA0..0xBF;
+			 * would fall in the range of UTF-16 surrogates
+			 * (0xD800..0xDFFF)
+			 */
+			*cp = GRAPHEME_INVALID_CODEPOINT;
+			return i;
+		}
+		if ((((*cp ^ 0x100) - 0x3C10) >> 8) == 0) {
+			/*
+			 * first byte 0xF0, second byte 0x80..0x8F or
+			 * first byte 0xF4, second byte 0x90..0xBF;
+			 * this would either form a 4-byte overlong
+			 * sequence or be not representable in UTF-16
+			 * (>0x10FFFF); two conditions checked together
+			 * with a bit hack
+			 */
+			*cp = GRAPHEME_INVALID_CODEPOINT;
+			return i;
+		}
 
-	if (*cp < lut[off].mincp ||
-	    BETWEEN(*cp, UINT32_C(0xD800), UINT32_C(0xDFFF)) ||
-	    *cp > UINT32_C(0x10FFFF)) {
-		/*
-		 * codepoint is overlong encoded in the sequence, is a
-		 * high or low UTF-16 surrogate half (0xD800..0xDFFF) or
-		 * not representable in UTF-16 (>0x10FFFF) (RFC-3629
-		 * specifies the latter two conditions)
-		 */
-		*cp = GRAPHEME_INVALID_CODEPOINT;
-	}
+		i++;
+	} while ((*cp & mask) != 0);
 
-	return 1 + off;
+	*cp = (i <= len) ?
+		(*cp & (mask - 1)) : GRAPHEME_INVALID_CODEPOINT;
+	return i;
 }
 
 size_t
 grapheme_encode_utf8(uint_least32_t cp, char *str, size_t len)
 {
-	size_t off, i;
+	size_t exp_len, i;
+	uint_least32_t first_byte;
+	unsigned int mask;
 
-	if (BETWEEN(cp, UINT32_C(0xD800), UINT32_C(0xDFFF)) ||
-	    cp > UINT32_C(0x10FFFF)) {
+	exp_len = 1;
+	first_byte = cp;
+	if (cp <= 0x7F) {
 		/*
-		 * codepoint is a high or low UTF-16 surrogate half
-		 * (0xD800..0xDFFF) or not representable in UTF-16
-		 * (>0x10FFFF), which RFC-3629 deems invalid for UTF-8.
+		 * ASCII range (0x00..0x7F); we assume ASCII characters
+		 * would appear the most often
 		 */
-		cp = GRAPHEME_INVALID_CODEPOINT;
-	}
+		mask = 0x7F;
+	} else {
+		if (BETWEEN(cp, UINT32_C(0xD800), UINT32_C(0xDFFF)) ||
+		    cp > UINT32_C(0x10FFFF)) {
+			/*
+			 * codepoint is a UTF-16 surrogate
+			 * (0xD800..0xDFFF) or not representable in
+			 * UTF-16 (>0x10FFFF), which RFC-3629 deems
+			 * invalid for UTF-8.
+			 */
+			cp = GRAPHEME_INVALID_CODEPOINT;
+			first_byte = cp;
+		}
 
-	/* determine necessary sequence type */
-	for (off = 0; off < LEN(lut); off++) {
-		if (cp <= lut[off].maxcp) {
-			break;
+		/* find the length needed to encode this codepoint */
+		mask = 0x3F;
+		do {
+			exp_len++;
+			first_byte >>= 6;
+			mask >>= 1;
+		} while (first_byte > mask);
+	}
+	if (exp_len <= len) {
+		/* build sequence by filling cp-bits into each byte */
+		((unsigned char *)str)[0] =
+			(uint_least8_t)((first_byte + (~mask << 1)) & 0xFF);
+		for (i = exp_len - 1; i > 0; i--) {
+			/*
+			 * the bit-format for following bytes is 10000000 (0x80)
+			 * and it each stores 6 bits in the 6 low bits that we
+			 * extract from the properly-shifted value using the
+			 * mask 00111111 (0x3F)
+			 */
+			((unsigned char *)str)[i] = 0x80 | (cp & 0x3F);
+			cp >>= 6;
 		}
 	}
-	if (1 + off > len || str == NULL || len == 0) {
-		/*
-		 * specified buffer is too small to store sequence or
-		 * the caller just wanted to know how many bytes the
-		 * codepoint needs by passing a NULL-buffer.
-		 */
-		return 1 + off;
-	}
-
-	/* build sequence by filling cp-bits into each byte */
-
-	/*
-	 * lut[off].lower is the bit-format for the first byte and
-	 * the bits to fill into it are determined by shifting the
-	 * cp 6 times the number of following bytes, as each
-	 * following byte stores 6 bits, yielding the wanted bits.
-	 *
-	 * We do not overwrite the mask because we guaranteed earlier
-	 * that there are no bits higher than the mask allows.
-	 */
-	((unsigned char *)str)[0] =
-		lut[off].lower | (uint_least8_t)(cp >> (6 * off));
-
-	for (i = 1; i <= off; i++) {
-		/*
-		 * the bit-format for following bytes is 10000000 (0x80)
-		 * and it each stores 6 bits in the 6 low bits that we
-		 * extract from the properly-shifted value using the
-		 * mask 00111111 (0x3F)
-		 */
-		((unsigned char *)str)[i] =
-			0x80 | ((cp >> (6 * (off - i))) & 0x3F);
-	}
-
-	return 1 + off;
+	return exp_len;
 }

--- a/test/utf8-decode.c
+++ b/test/utf8-decode.c
@@ -24,7 +24,17 @@ static const struct {
 		.exp_cp = GRAPHEME_INVALID_CODEPOINT,
 	},
 	{
-		/* invalid lead byte
+		/* invalid lead byte (continuation byte as lead byte)
+	         * [ 10111111 ] ->
+	         * INVALID
+	         */
+		.arr = (char *)(unsigned char[]) { 0xBF },
+		.len = 1,
+		.exp_len = 1,
+		.exp_cp = GRAPHEME_INVALID_CODEPOINT,
+	},
+	{
+		/* invalid lead byte (UTF-16-unrepresentable)
 	         * [ 11111101 ] ->
 	         * INVALID
 	         */
@@ -80,6 +90,16 @@ static const struct {
 	         */
 		.arr = (char *)(unsigned char[]) { 0xC1, 0xBF },
 		.len = 2,
+		.exp_len = 1,
+		.exp_cp = GRAPHEME_INVALID_CODEPOINT,
+	},
+	{
+		/* invalid 2-byte sequence (short string, overlong encoded)
+	         * [ 11000001 ] ->
+	         * INVALID
+	         */
+		.arr = (char *)(unsigned char[]) { 0xC1 },
+		.len = 1,
 		.exp_len = 1,
 		.exp_cp = GRAPHEME_INVALID_CODEPOINT,
 	},
@@ -154,12 +174,32 @@ static const struct {
 		.exp_cp = GRAPHEME_INVALID_CODEPOINT,
 	},
 	{
-		/* invalid 3-byte sequence (UTF-16 surrogate half)
+		/* invalid 3-byte sequence (short string, overlong encoded)
+	         * [ 11100000 10011111 ] ->
+	         * INVALID
+	         */
+		.arr = (char *)(unsigned char[]) { 0xE0, 0x9F },
+		.len = 2,
+		.exp_len = 1,
+		.exp_cp = GRAPHEME_INVALID_CODEPOINT,
+	},
+	{
+		/* invalid 3-byte sequence (UTF-16 surrogate)
 	         * [ 11101101 10100000 10000000 ] ->
 	         * INVALID
 	         */
 		.arr = (char *)(unsigned char[]) { 0xED, 0xA0, 0x80 },
 		.len = 3,
+		.exp_len = 1,
+		.exp_cp = GRAPHEME_INVALID_CODEPOINT,
+	},
+	{
+		/* invalid 3-byte sequence (short string, UTF-16 surrogate)
+	         * [ 11101101 10100000 ] ->
+	         * INVALID
+	         */
+		.arr = (char *)(unsigned char[]) { 0xED, 0xA0 },
+		.len = 2,
 		.exp_len = 1,
 		.exp_cp = GRAPHEME_INVALID_CODEPOINT,
 	},
@@ -273,12 +313,32 @@ static const struct {
 		.exp_cp = GRAPHEME_INVALID_CODEPOINT,
 	},
 	{
+		/* invalid 4-byte sequence (short string, overlong encoded)
+	         * [ 11110000 10000000 ] ->
+	         * INVALID
+	         */
+		.arr = (char *)(unsigned char[]) { 0xF0, 0x80 },
+		.len = 2,
+		.exp_len = 1,
+		.exp_cp = GRAPHEME_INVALID_CODEPOINT,
+	},
+	{
 		/* invalid 4-byte sequence (UTF-16-unrepresentable)
 	         * [ 11110100 10010000 10000000 10000000 ] ->
 	         * INVALID
 	         */
 		.arr = (char *)(unsigned char[]) { 0xF4, 0x90, 0x80, 0x80 },
 		.len = 4,
+		.exp_len = 1,
+		.exp_cp = GRAPHEME_INVALID_CODEPOINT,
+	},
+	{
+		/* invalid 4-byte sequence (short string, UTF-16-unrepresentable)
+	         * [ 11110100 10010000 ] ->
+	         * INVALID
+	         */
+		.arr = (char *)(unsigned char[]) { 0xF4, 0x90 },
+		.len = 2,
 		.exp_len = 1,
 		.exp_cp = GRAPHEME_INVALID_CODEPOINT,
 	},

--- a/test/utf8-decode.c
+++ b/test/utf8-decode.c
@@ -80,7 +80,7 @@ static const struct {
 	         */
 		.arr = (char *)(unsigned char[]) { 0xC1, 0xBF },
 		.len = 2,
-		.exp_len = 2,
+		.exp_len = 1,
 		.exp_cp = GRAPHEME_INVALID_CODEPOINT,
 	},
 	{
@@ -150,7 +150,7 @@ static const struct {
 	         */
 		.arr = (char *)(unsigned char[]) { 0xE0, 0x9F, 0xBF },
 		.len = 3,
-		.exp_len = 3,
+		.exp_len = 1,
 		.exp_cp = GRAPHEME_INVALID_CODEPOINT,
 	},
 	{
@@ -160,7 +160,7 @@ static const struct {
 	         */
 		.arr = (char *)(unsigned char[]) { 0xED, 0xA0, 0x80 },
 		.len = 3,
-		.exp_len = 3,
+		.exp_len = 1,
 		.exp_cp = GRAPHEME_INVALID_CODEPOINT,
 	},
 	{
@@ -269,7 +269,7 @@ static const struct {
 	         */
 		.arr = (char *)(unsigned char[]) { 0xF0, 0x80, 0x81, 0xBF },
 		.len = 4,
-		.exp_len = 4,
+		.exp_len = 1,
 		.exp_cp = GRAPHEME_INVALID_CODEPOINT,
 	},
 	{
@@ -279,7 +279,7 @@ static const struct {
 	         */
 		.arr = (char *)(unsigned char[]) { 0xF4, 0x90, 0x80, 0x80 },
 		.len = 4,
-		.exp_len = 4,
+		.exp_len = 1,
 		.exp_cp = GRAPHEME_INVALID_CODEPOINT,
 	},
 };


### PR DESCRIPTION
I am donating my algorithms for UTF-8 decode and encode functions for use in libgrapheme.

(The original code was posted by me as [a snippet on GitLab](https://gitlab.com/-/snippets/3718423))

The new UTF-8 decode and encode functions:
* No longer need a lookup table for getting the length or codepoint range of a UTF-8 sequence (it is now done with a loop with clever bit testing),
* Assume codepoints in the ASCII range (0x00..0x7F) appear more frequently and thus check the ASCII range first,
* Are smaller in compiled code size, and
* Compatible with [WHATWG Encoding Standard on the UTF-8 decoder](https://encoding.spec.whatwg.org/#utf-8-decoder), specifically on how the lengths of the ill-formed sequences are counted.

In Unicode the algorithm is known as "[Maximal subpart of the ill-formed subsequence](https://www.unicode.org/versions/Unicode17.0.0/core-spec/chapter-3/#G66453)". For compliance with this algorithm, the lengths returned from overlong sequences, UTF-16 surrogate codepoints and codepoints not representable in UTF-16 (>0x10FFFF) are now different. The testcases (test/utf8-decode.c) are updated to reflect the new behavior.